### PR TITLE
인증이 필요한 엔드포인트를 위한 토큰 관리 시스템

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.23.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "vite": "^5.2.0",
         "vite-plugin-next-react-router": "^0.7.1"
       },
@@ -3522,6 +3523,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "vite": "^5.2.0",
     "vite-plugin-next-react-router": "^0.7.1"
   },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,8 +6,16 @@ import './index.css';
 
 // Patch fetch API: 기본 api hostname 설정
 const orgFetch = window.fetch;
-window.fetch = (url, ...params) => {
-  if (url.startsWith('/')) return orgFetch(`/api${url}`, ...params);
+window.fetch = (url, init) => {
+  // eslint-disable-next-line prefer-const
+  let { headers, ...params } = init || {};
+  headers = { ...(headers || {}) };
+
+  const { token } = params;
+  if (token) headers = { ...headers, Authorization: `Bearer ${token}` };
+
+  if (url.startsWith('/'))
+    return orgFetch(`/api${url}`, { headers, ...params });
   return orgFetch(url, ...params);
 };
 

--- a/src/pages/partners/myProducts/index.jsx
+++ b/src/pages/partners/myProducts/index.jsx
@@ -1,14 +1,20 @@
 import { useState, useEffect } from 'react';
 import '../index.css';
+import { useRecoilState } from 'recoil';
 import Clickable from '../../../components/Clickable';
+import loginState from '../../../state';
 
 const OrderList = () => {
+  const [loginData] = useRecoilState(loginState);
   const [products, setProducts] = useState([]);
+
+  const { token } = loginData;
 
   useEffect(() => {
     const fetchProductsBySeller = async () => {
-      const resp = await fetch('/api/products/my');
+      const resp = await fetch('/products/my', { token });
       const data = await resp.json();
+
       // 출력할 제품 정보들
       const filteredProducts = data.map((product) => ({
         name: product.name,
@@ -17,14 +23,12 @@ const OrderList = () => {
         quantity: product.quantity,
         price: product.price,
       }));
+
       setProducts(filteredProducts);
     };
-    fetchProductsBySeller();
-  }, []);
 
-  // 로그인된 경우는 어떻게 설정해야하는지..?
-  const [loginInfo, setLoginInfo] = useState(undefined);
-  const myPageBox = loginInfo === undefined;
+    fetchProductsBySeller();
+  }, [token]);
 
   return (
     <div>

--- a/src/state.jsx
+++ b/src/state.jsx
@@ -1,4 +1,7 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 const loginState = atom({
   key: 'loginState',
@@ -8,6 +11,7 @@ const loginState = atom({
     token: undefined,
     meta: {},
   },
+  effects_UNSTABLE: [persistAtom],
 });
 
 export default loginState;


### PR DESCRIPTION
우리 프로젝트는 JWT를 이용한 인증 방식을 사용하고 있습니다. 가장 대표적인 예시로 [`/api/me` 라는 엔드포인트](https://api.coffee.ajou.enak.kr/swagger-ui/#/1.%20%EC%9D%B8%EC%A6%9D/whoAmIUsingGET)는 목록 우측에 자물쇠 표시로 이 엔드포인트가 인증을 필요로 함을 알려줍니다.

로그인은 아래와 같이 구현이 되어있습니다. 서버에 로그인을 요청하면 JWT 토큰을 반환하고, 이를 recoil 의 loginState 에 저장합니다.
https://github.com/return0927/coffeebean-front/blob/79ce9ee4dab225a317dc211cca8deef6899c6e3a/src/pages/login/customer/index.jsx#L21-L55

이렇게 저장한 데이터는 아래의 예시처럼 받아올 수 있습니다.
https://github.com/return0927/coffeebean-front/blob/cff05c24be94bc036aaaf41d196d047ac08f5581/src/pages/partners/myProducts/index.jsx#L7-L31


